### PR TITLE
Remove comments from SQL when migration is rendered

### DIFF
--- a/migro/migrations.py
+++ b/migro/migrations.py
@@ -1,5 +1,6 @@
 import os
 import random
+import sqlparse
 import string
 
 from datetime import datetime
@@ -31,7 +32,7 @@ class Migration:
         sql = jinja.render_jinja_template(
             f"{MIGRATION_FILE_PATH}/{self.file_path}", password=self._password()
         )
-        return sql.strip()
+        return sqlparse.format(sql, strip_comments=True).strip()
 
 
 class MigrationRepository:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='migro',
-    version='0.0.6',
+    version='0.0.7',
     description='Redshift Data Warehouse migrations for dbt.',
     author='Troy Harvey',
     author_email='troyharvey@gmail.com',
@@ -23,6 +23,7 @@ setup(
         'Jinja2',
         'psycopg2',
         'pyyaml',
+        'sqlparse',
     ],
     extras_require={
         'dev': [

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -65,7 +65,11 @@ class TestMigrationRepository:
 class TestMigration:
     def setup_method(self):
         with open(f"{migrations.MIGRATION_FILE_PATH}/test.sql", "w") as f:
-            f.write("select '{{password}}' as pw;")
+            f.write("""
+                -- This comment should be removed when sql is rendered
+                select '{{password}}' as pw;
+                """
+            )
 
     def teardown_method(self):
         try:
@@ -85,4 +89,5 @@ class TestMigration:
     def test_sql(self):
         m = migrations.Migration()
         m.file_path = "test.sql"
-        assert re.match(f"^select '{PASSWORD_REGEX}' as pw;$", m.sql())
+        sql = m.sql()
+        assert re.match(f"^select '{PASSWORD_REGEX}' as pw;$", sql)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -65,7 +65,8 @@ class TestMigrationRepository:
 class TestMigration:
     def setup_method(self):
         with open(f"{migrations.MIGRATION_FILE_PATH}/test.sql", "w") as f:
-            f.write("""
+            f.write(
+                """
                 -- This comment should be removed when sql is rendered
                 select '{{password}}' as pw;
                 """


### PR DESCRIPTION
## Problem

Migration files with only comments fail to apply.

```
Migrating: 20220106215361_grant_crh_schema_to_dbt_contributors.sql
-- Add the dbt contributors group to the crh schema
...
psycopg2.ProgrammingError: can't execute an empty query
```

## Solution

Remove comments when rendering migrations.